### PR TITLE
build(CI): test CI on wrong e2e test (G3.6)

### DIFF
--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -1,5 +1,5 @@
 describe('template spec', () => {
   it('passes', () => {
-    cy.visit('https://example.cypress.io')
+    cy.visit('https://example.cypresss.io')
   })
 })


### PR DESCRIPTION
### Описание изменений
Данный PR демонстрирует работу CI, которая запрещает закрыть PR, если не пройдено e2e тестирование. (G3.6)
