### PR TITLE
feat(core): add multiple property, rename field in property.ts

### DIFF
--- a/src/editor/core/property/MultipleProperty.ts
+++ b/src/editor/core/property/MultipleProperty.ts
@@ -1,0 +1,25 @@
+import Component from '@/editor/core/component/Component.ts';
+import Attribute from '@/editor/core/attribute/Attribute.ts';
+import Property from '@/editor/core/property/Property.ts';
+
+export default abstract class MultipleProperty extends Property {
+  public abstract title: string;
+  public abstract description: string;
+  public abstract availableValues: Record<string, any>;
+  public abstract defaultValue: string;
+
+  protected constructor(public values: []) {
+    super();
+  }
+
+  override apply(target: Component): Component {
+    this.values.forEach((value) => {
+      target.attributes.append(
+        new Attribute('class', this.availableValues[value]),
+      );
+    });
+    return target;
+  }
+
+  public abstract getName(): string;
+}

--- a/src/editor/core/property/Property.ts
+++ b/src/editor/core/property/Property.ts
@@ -9,13 +9,15 @@ export type PropertyObject = {
 export default abstract class Property {
   public abstract title: string;
   public abstract description: string;
-  public abstract values: Record<string, any>;
+  public abstract availableValues: Record<string, any>;
   public abstract defaultValue: string;
 
   constructor(public value: string) {}
 
   public apply(target: Component): Component {
-    target.attributes.append(new Attribute('class', this.values[this.value]));
+    target.attributes.append(
+      new Attribute('class', this.availableValues[this.value]),
+    );
 
     return target;
   }

--- a/src/editor/properties/AlignItemsProp.ts
+++ b/src/editor/properties/AlignItemsProp.ts
@@ -6,7 +6,7 @@ export default class AlignItemsProp extends Property {
   defaultValue: string = 'start';
   description: string = '___';
   title: string = '___';
-  values: Record<string, any> = {
+  availableValues: Record<string, any> = {
     start: 'align-items-start',
     end: 'align-items-end',
     center: 'align-items-center',

--- a/src/editor/properties/AlignSelfProp.ts
+++ b/src/editor/properties/AlignSelfProp.ts
@@ -6,7 +6,7 @@ export default class AlignSelfProp extends Property {
   defaultValue: string = 'start';
   description: string = '___';
   title: string = '___';
-  values: Record<string, any> = {
+  availableValues: Record<string, any> = {
     start: 'align-self-start',
     end: 'align-self-end',
     center: 'align-self-center',

--- a/src/editor/properties/ColWidthProp.ts
+++ b/src/editor/properties/ColWidthProp.ts
@@ -6,7 +6,7 @@ export default class ColWidthProp extends Property {
   defaultValue: string = 'col';
   description: string = '___';
   title: string = '___';
-  values: Record<string, any> = {
+  availableValues: Record<string, any> = {
     c1: 'col-1',
     c2: 'col-2',
     c3: 'col-3',

--- a/src/editor/properties/FlexDirectionProp.ts
+++ b/src/editor/properties/FlexDirectionProp.ts
@@ -6,7 +6,7 @@ export default class FlexDirectionProp extends Property {
   defaultValue: string = 'row';
   description: string = 'Description';
   title: string = '----';
-  values: Record<string, any> = {
+  availableValues: Record<string, any> = {
     row: 'flex-row',
     col: 'flex-column',
   };

--- a/src/editor/properties/FlexProp.ts
+++ b/src/editor/properties/FlexProp.ts
@@ -6,7 +6,7 @@ export default class FlexProp extends Property {
   defaultValue: string = 'flex';
   description: string = '___';
   title: string = '___';
-  values: Record<string, any> = { flex: 'd-flex' };
+  availableValues: Record<string, any> = { flex: 'd-flex' };
 
   getName(): string {
     return FlexProp.name;

--- a/src/editor/properties/FlexWrapProp.ts
+++ b/src/editor/properties/FlexWrapProp.ts
@@ -6,7 +6,7 @@ export default class FlexWrapProp extends Property {
   defaultValue: string = 'flex-wrap';
   description: string = '___';
   title: string = '___';
-  values: Record<string, any> = { 'flex-wrap': 'flex-wrap' };
+  availableValues: Record<string, any> = { 'flex-wrap': 'flex-wrap' };
 
   getName(): string {
     return FlexWrapProp.name;

--- a/src/editor/properties/GutterProp.ts
+++ b/src/editor/properties/GutterProp.ts
@@ -6,7 +6,7 @@ export default class GutterProp extends Property {
   defaultValue: string = 'g0';
   description: string = '___';
   title: string = '___';
-  values: Record<string, any> = {
+  availableValues: Record<string, any> = {
     g0: 'gap-0',
     g1: 'gap-1',
     g2: 'gap-2',

--- a/src/editor/properties/JustifyContentProp.ts
+++ b/src/editor/properties/JustifyContentProp.ts
@@ -6,7 +6,7 @@ export default class JustifyContentProp extends Property {
   defaultValue: string = 'start';
   description: string = '___';
   title: string = '___';
-  values: Record<string, any> = {
+  availableValues: Record<string, any> = {
     start: 'justify-content-start',
     end: 'justify-content-end',
     center: 'justify-content-center',

--- a/test/editor/core/multiple-property.test.ts
+++ b/test/editor/core/multiple-property.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Attribute from '@/editor/core/attribute/Attribute.ts';
+import MultipleProperty from '@/editor/core/property/MultipleProperty.ts';
+import { App } from '@/editor/App.ts';
+import Component, {
+  ComponentObject,
+} from '@/editor/core/component/Component.ts';
+
+class TestComponent extends Component {
+  name: string = 'TestComponent';
+  htmlElement = document.createElement('div');
+}
+
+class MulProp extends MultipleProperty {
+  static name: string = 'mul-name';
+
+  public values = ['start', 'end'];
+  availableValues: Record<string, any> = {
+    start: 'mul-name-start',
+    end: 'mul-name-end',
+  };
+
+  getName(): string {
+    return MulProp.name;
+  }
+}
+
+describe('Base property class tests', () => {
+  const propertyValue1 = 'prop-val-1';
+  const propertyValue2 = 'prop-val-2';
+
+  let property: MultipleProperty;
+  beforeEach(() => {
+    //@ts-ignore
+    property = new MultipleProperty([propertyValue1, propertyValue2]);
+  });
+  it('Test property creation', () => {
+    expect(property.values).toStrictEqual([propertyValue1, propertyValue2]);
+  });
+
+  it('Test props applying', () => {
+    const targetMock = {
+      attributes: {
+        append: vi.fn(),
+      },
+    };
+
+    const propertyClassValue1 = 'test-class-1';
+    const propertyClassValue2 = 'test-class-2';
+    property.availableValues = {
+      [propertyValue1]: propertyClassValue1,
+      [propertyValue2]: propertyClassValue2,
+    };
+    //@ts-ignore
+    property.apply(targetMock);
+
+    expect(targetMock.attributes.append).toBeCalledTimes(2);
+    expect(targetMock.attributes.append).toBeCalledWith(
+      new Attribute('class', propertyClassValue1),
+    );
+    expect(targetMock.attributes.append).toBeCalledWith(
+      new Attribute('class', propertyClassValue2),
+    );
+  });
+
+  it('Test on success mount', () => {
+    const app = new App();
+    const mountPoint = 'app-root';
+    const identifierSalt = 'salt';
+    const state: ComponentObject[] = [
+      {
+        key: 'data-123',
+        name: 'testComponent',
+        attrs: [],
+        props: [
+          {
+            name: 'mul-name',
+            value: 'start',
+          },
+          {
+            name: 'mul-name',
+            value: 'end',
+          },
+        ],
+        content: 'test content',
+        children: [],
+      },
+    ];
+
+    document.body.innerHTML = `<div data-scope id="${mountPoint}" ></div>`;
+    app.useProp(MulProp);
+    app.use('testComponent', TestComponent);
+    app.init(mountPoint, identifierSalt, state);
+    app.mount();
+
+    const el = document.getElementById('app-root').children[0] as HTMLElement;
+    expect(el.attributes.item(2).name).toBe('class');
+    expect(el.attributes.item(2).value).toBe(' mul-name-start mul-name-end');
+  });
+});

--- a/test/editor/core/property.test.ts
+++ b/test/editor/core/property.test.ts
@@ -21,7 +21,7 @@ describe('Base property class tests', () => {
     };
 
     const propertyClassValue = 'test-class';
-    property.values = {
+    property.availableValues = {
       [propertyValue]: propertyClassValue,
     };
     //@ts-ignore

--- a/test/editor/properties/align-items-prop.test.ts
+++ b/test/editor/properties/align-items-prop.test.ts
@@ -9,7 +9,7 @@ describe('Align Items prop test', () => {
     expect(alignItemsProp.defaultValue).toBe('start');
     expect(alignItemsProp.description).toBe('___');
     expect(alignItemsProp.title).toBe('___');
-    expect(alignItemsProp.values).toStrictEqual({
+    expect(alignItemsProp.availableValues).toStrictEqual({
       start: 'align-items-start',
       end: 'align-items-end',
       center: 'align-items-center',

--- a/test/editor/properties/align-self-prop.test.ts
+++ b/test/editor/properties/align-self-prop.test.ts
@@ -9,7 +9,7 @@ describe('Align Self prop test', () => {
     expect(alignSelfProp.defaultValue).toBe('start');
     expect(alignSelfProp.description).toBe('___');
     expect(alignSelfProp.title).toBe('___');
-    expect(alignSelfProp.values).toStrictEqual({
+    expect(alignSelfProp.availableValues).toStrictEqual({
       start: 'align-self-start',
       end: 'align-self-end',
       center: 'align-self-center',

--- a/test/editor/properties/col-width.test.ts
+++ b/test/editor/properties/col-width.test.ts
@@ -9,7 +9,7 @@ describe('Col width prop test', () => {
     expect(justifyContentProp.defaultValue).toBe('col');
     expect(justifyContentProp.description).toBe('___');
     expect(justifyContentProp.title).toBe('___');
-    expect(justifyContentProp.values).toStrictEqual({
+    expect(justifyContentProp.availableValues).toStrictEqual({
       c1: 'col-1',
       c2: 'col-2',
       c3: 'col-3',

--- a/test/editor/properties/flex-direction-prop.test.ts
+++ b/test/editor/properties/flex-direction-prop.test.ts
@@ -9,7 +9,7 @@ describe('Flex direction prop test', () => {
     expect(fdProp.defaultValue).toBe('row');
     expect(fdProp.description).toBe('Description');
     expect(fdProp.title).toBe('----');
-    expect(fdProp.values).toStrictEqual({
+    expect(fdProp.availableValues).toStrictEqual({
       row: 'flex-row',
       col: 'flex-column',
     });

--- a/test/editor/properties/flex-prop.test.ts
+++ b/test/editor/properties/flex-prop.test.ts
@@ -9,7 +9,7 @@ describe('Flex prop test', () => {
     expect(fdProp.defaultValue).toBe('flex');
     expect(fdProp.description).toBe('___');
     expect(fdProp.title).toBe('___');
-    expect(fdProp.values).toStrictEqual({ flex: 'd-flex' });
+    expect(fdProp.availableValues).toStrictEqual({ flex: 'd-flex' });
     expect(FlexProp.name).toBe('flex');
   });
 

--- a/test/editor/properties/flex-wrap-prop.test.ts
+++ b/test/editor/properties/flex-wrap-prop.test.ts
@@ -9,7 +9,7 @@ describe('Flex wrap prop test', () => {
     expect(fdProp.defaultValue).toBe('flex-wrap');
     expect(fdProp.description).toBe('___');
     expect(fdProp.title).toBe('___');
-    expect(fdProp.values).toStrictEqual({ 'flex-wrap': 'flex-wrap' });
+    expect(fdProp.availableValues).toStrictEqual({ 'flex-wrap': 'flex-wrap' });
     expect(FlexWrapProp.name).toBe('flex-wrap');
   });
 

--- a/test/editor/properties/gutter-prop.test.ts
+++ b/test/editor/properties/gutter-prop.test.ts
@@ -9,7 +9,7 @@ describe('Gutter prop test', () => {
     expect(fdProp.defaultValue).toBe('g0');
     expect(fdProp.description).toBe('___');
     expect(fdProp.title).toBe('___');
-    expect(fdProp.values).toStrictEqual({
+    expect(fdProp.availableValues).toStrictEqual({
       g0: 'gap-0',
       g1: 'gap-1',
       g2: 'gap-2',

--- a/test/editor/properties/justify-content-prop.test.ts
+++ b/test/editor/properties/justify-content-prop.test.ts
@@ -9,7 +9,7 @@ describe('Justify-content prop test', () => {
     expect(justifyContentProp.defaultValue).toBe('start');
     expect(justifyContentProp.description).toBe('___');
     expect(justifyContentProp.title).toBe('___');
-    expect(justifyContentProp.values).toStrictEqual({
+    expect(justifyContentProp.availableValues).toStrictEqual({
       start: 'justify-content-start',
       end: 'justify-content-end',
       center: 'justify-content-center',


### PR DESCRIPTION
### Описание изменений
Реализован абстрактный класс MultiProperty, который позволяет накладывать несколько параметров одного типа на компоненту.

### Тип изменений
- [x] Новая функциональность
- [ ] Исправление ошибок
- [ ] Улучшение существующего кода
- [ ] Другие изменения

### Тестирование
Новая класс был протестирован unit-тестами (включая тест на проверку монтирования компоненты с multi-property).

