### PR TITLE
Add properties for header, text (includes link, list), img (fluid only)

### DIFF
--- a/src/editor/properties/BorderRadiusProp.ts
+++ b/src/editor/properties/BorderRadiusProp.ts
@@ -1,0 +1,21 @@
+import Property from '../core/property/Property';
+
+export default class BorderRadiusProp extends Property {
+  static name: string = 'border-radius';
+
+  defaultValue: string = 'r0';
+  description: string = '___';
+  title: string = '___';
+  availableValues: Record<string, any> = {
+    r0: 'rounded-0',
+    r1: 'rounded-1',
+    r2: 'rounded-2',
+    r3: 'rounded-3',
+    r4: 'rounded-4',
+    r5: 'rounded-5',
+  };
+
+  getName(): string {
+    return BorderRadiusProp.name;
+  }
+}

--- a/src/editor/properties/ImgFluidProp.ts
+++ b/src/editor/properties/ImgFluidProp.ts
@@ -1,0 +1,16 @@
+import Property from '../core/property/Property';
+
+export default class ImgFluidProp extends Property {
+  static name: string = 'img-fluid';
+
+  defaultValue: string = 'imgFluid';
+  description: string = '___';
+  title: string = '___';
+  availableValues: Record<string, any> = {
+    imgFluid: 'img-fluid',
+  };
+
+  getName(): string {
+    return ImgFluidProp.name;
+  }
+}

--- a/src/editor/properties/link/LinkOpacityProp.ts
+++ b/src/editor/properties/link/LinkOpacityProp.ts
@@ -1,0 +1,25 @@
+import Property from '../../core/property/Property.ts';
+
+export default class LinkOpacityProp extends Property {
+  static name: string = 'link-opacity';
+
+  defaultValue: string = 'opacity100';
+  description: string = '___';
+  title: string = '___';
+  availableValues: Record<string, any> = {
+    opacity10: 'link-opacity-10',
+    opacity25: 'link-opacity-25',
+    opacity50: 'link-opacity-50',
+    opacity75: 'link-opacity-75',
+    opacity100: 'link-opacity-100',
+    opacityHover10: 'link-opacity-10-hover',
+    opacityHover25: 'link-opacity-25-hover',
+    opacityHover50: 'link-opacity-50-hover',
+    opacityHover75: 'link-opacity-75-hover',
+    opacityHover100: 'link-opacity-100-hover',
+  };
+
+  getName(): string {
+    return LinkOpacityProp.name;
+  }
+}

--- a/src/editor/properties/link/LinkUnderlineOffsetProp.ts
+++ b/src/editor/properties/link/LinkUnderlineOffsetProp.ts
@@ -1,0 +1,18 @@
+import Property from '../../core/property/Property.ts';
+
+export default class LinkUnderlineOffsetProp extends Property {
+  static name: string = 'link-offset';
+
+  defaultValue: string = 'link-offset-1';
+  description: string = '___';
+  title: string = '___';
+  availableValues: Record<string, any> = {
+    one: 'link-offset-1',
+    two: 'link-offset-2',
+    three: 'link-offset-3',
+  };
+
+  getName(): string {
+    return LinkUnderlineOffsetProp.name;
+  }
+}

--- a/src/editor/properties/link/LinkUnderlineOpacity.ts
+++ b/src/editor/properties/link/LinkUnderlineOpacity.ts
@@ -1,0 +1,21 @@
+import Property from '../../core/property/Property.ts';
+
+export default class LinkUnderlineOpacity extends Property {
+  static name: string = 'link-underline-opacity';
+
+  defaultValue: string = 'opacity100';
+  description: string = '___';
+  title: string = '___';
+  availableValues: Record<string, any> = {
+    opacity0: 'link-underline-opacity-0',
+    opacity10: 'link-underline-opacity-10',
+    opacity25: 'link-underline-opacity-25',
+    opacity50: 'link-underline-opacity-50',
+    opacity75: 'link-underline-opacity-75',
+    opacity100: 'link-underline-opacity-100',
+  };
+
+  getName(): string {
+    return LinkUnderlineOpacity.name;
+  }
+}

--- a/src/editor/properties/link/LinkUnderlineProp.ts
+++ b/src/editor/properties/link/LinkUnderlineProp.ts
@@ -1,0 +1,23 @@
+import Property from '../../core/property/Property.ts';
+
+export default class LinkUnderlineProp extends Property {
+  static name: string = 'link-underline';
+
+  defaultValue: string = 'primary';
+  description: string = '___';
+  title: string = '___';
+  availableValues: Record<string, any> = {
+    primary: 'link-underline-primary',
+    secondary: 'link-underline-secondary',
+    success: 'link-underline-success',
+    danger: 'link-underline-danger',
+    warning: 'link-underline-warning',
+    info: 'link-underline-info',
+    light: 'link-underline-light',
+    dark: 'link-underline-dark',
+  };
+
+  getName(): string {
+    return LinkUnderlineProp.name;
+  }
+}

--- a/src/editor/properties/text/FontWeightProp.ts
+++ b/src/editor/properties/text/FontWeightProp.ts
@@ -1,0 +1,24 @@
+import Property from '../../core/property/Property.ts';
+
+export default class FontWeightProp extends Property {
+  static name: string = 'fw';
+
+  defaultValue: string = 'normal';
+  description: string = '___';
+  title: string = '___';
+  availableValues: Record<string, any> = {
+    bold: 'fw-bold',
+    bolder: 'fw-bolder',
+    semibold: 'fw-semibold',
+    medium: 'fw-medium',
+    normal: 'fw-normal',
+    light: 'fw-light',
+    lighter: 'fw-lighter',
+    italic: 'fst-italic',
+    normal: 'fst-normal',
+  };
+
+  getName(): string {
+    return FontWeightProp.name;
+  }
+}

--- a/src/editor/properties/text/InlineTextProps.ts
+++ b/src/editor/properties/text/InlineTextProps.ts
@@ -1,0 +1,21 @@
+import MultipleProperty from '@/editor/core/property/MultipleProperty.ts';
+
+export default class InlineTextProps extends MultipleProperty {
+  static name: string = 'inline-text';
+
+  defaultValue: string = 'empty';
+  description: string = '___';
+  title: string = '___';
+  availableValues: Record<string, any> = {
+    empty: '',
+    mark: 'mark',
+    small: 'small',
+    textDecorationUnderline: 'text-decoration-underline',
+    textDecorationLineThrough: 'text-decoration-line-through',
+    textDecorationNone: 'text-decoration-none',
+  };
+
+  getName(): string {
+    return InlineTextProps.name;
+  }
+}

--- a/src/editor/properties/text/LeadParagraphProp.ts
+++ b/src/editor/properties/text/LeadParagraphProp.ts
@@ -1,0 +1,16 @@
+import Property from '../../core/property/Property.ts';
+
+export default class LeadParagraphProp extends Property {
+  static name: string = 'lead-paragraph';
+
+  defaultValue: string = 'lead';
+  description: string = '___';
+  title: string = '___';
+  availableValues: Record<string, any> = {
+    lead: 'lead',
+  };
+
+  getName(): string {
+    return LeadParagraphProp.name;
+  }
+}

--- a/src/editor/properties/text/LineHeightProp.ts
+++ b/src/editor/properties/text/LineHeightProp.ts
@@ -1,0 +1,19 @@
+import Property from '../../core/property/Property.ts';
+
+export default class LineHeightProp extends Property {
+  static name: string = 'lh';
+
+  defaultValue: string = 'base';
+  description: string = '___';
+  title: string = '___';
+  availableValues: Record<string, any> = {
+    one: 'lh-1',
+    small: 'lh-sm',
+    base: 'lh-base',
+    large: 'lh-lg',
+  };
+
+  getName(): string {
+    return LineHeightProp.name;
+  }
+}

--- a/src/editor/properties/text/ListInlineProp.ts
+++ b/src/editor/properties/text/ListInlineProp.ts
@@ -1,0 +1,17 @@
+import Property from '../../core/property/Property.ts';
+
+export default class ListInlineProp extends Property {
+  static name: string = 'list-inline';
+
+  defaultValue: string = 'inline';
+  description: string = '___';
+  title: string = '___';
+  availableValues: Record<string, any> = {
+    inline: 'list-inline',
+    item: 'list-inline-item',
+  };
+
+  getName(): string {
+    return ListInlineProp.name;
+  }
+}

--- a/src/editor/properties/text/ListUnstyledProp.ts
+++ b/src/editor/properties/text/ListUnstyledProp.ts
@@ -1,0 +1,16 @@
+import Property from '../../core/property/Property.ts';
+
+export default class ListUnstyledProp extends Property {
+  static name: string = 'list-unstyled';
+
+  defaultValue: string = 'unstyled';
+  description: string = '___';
+  title: string = '___';
+  availableValues: Record<string, any> = {
+    unsyled: 'list-unstyled',
+  };
+
+  getName(): string {
+    return ListUnstyledProp.name;
+  }
+}

--- a/src/editor/properties/text/MonoSpaceProp.ts
+++ b/src/editor/properties/text/MonoSpaceProp.ts
@@ -1,0 +1,16 @@
+import Property from '../../core/property/Property.ts';
+
+export default class MonoSpaceProp extends Property {
+  static name: string = 'font-monospace';
+
+  defaultValue: string = 'monospace';
+  description: string = '___';
+  title: string = '___';
+  availableValues: Record<string, any> = {
+    monospace: 'font-monospace',
+  };
+
+  getName(): string {
+    return MonoSpaceProp.name;
+  }
+}

--- a/src/editor/properties/text/TextAlignProp.ts
+++ b/src/editor/properties/text/TextAlignProp.ts
@@ -1,0 +1,18 @@
+import Property from '../../core/property/Property.ts';
+
+export default class TextAlignProp extends Property {
+  static name: string = 'text-align';
+
+  defaultValue: string = 'start';
+  description: string = '___';
+  title: string = '___';
+  availableValues: Record<string, any> = {
+    start: 'text-start',
+    end: 'text-end',
+    center: 'text-center',
+  };
+
+  getName(): string {
+    return TextAlignProp.name;
+  }
+}

--- a/src/editor/properties/text/TextTransformProp.ts
+++ b/src/editor/properties/text/TextTransformProp.ts
@@ -1,0 +1,18 @@
+import Property from '../../core/property/Property.ts';
+
+export default class TextTransformProp extends Property {
+  static name: string = 'text-transform';
+
+  defaultValue: string = 'text-capitalize';
+  description: string = '___';
+  title: string = '___';
+  availableValues: Record<string, any> = {
+    lowercase: 'text-lowercase',
+    uppercase: 'text-uppercase',
+    capitalize: 'text-capitalize',
+  };
+
+  getName(): string {
+    return TextTransformProp.name;
+  }
+}

--- a/test/editor/properties/border-radius-prop.test.ts
+++ b/test/editor/properties/border-radius-prop.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import BorderRadiusProp from '@/editor/properties/BorderRadiusProp.ts';
+
+describe('Border Radius prop test', () => {
+  it('Correct class creation', () => {
+    const borderRadiusProp = new BorderRadiusProp('value');
+
+    expect(borderRadiusProp.value).toBe('value');
+    expect(borderRadiusProp.defaultValue).toBe('r0');
+    expect(borderRadiusProp.description).toBe('___');
+    expect(borderRadiusProp.title).toBe('___');
+    expect(borderRadiusProp.availableValues).toStrictEqual({
+      r0: 'rounded-0',
+      r1: 'rounded-1',
+      r2: 'rounded-2',
+      r3: 'rounded-3',
+      r4: 'rounded-4',
+      r5: 'rounded-5',
+    });
+    expect(BorderRadiusProp.name).toBe('border-radius');
+  });
+
+  it('Correct name getter', () => {
+    const borderRadiusProp = new BorderRadiusProp('value');
+
+    expect(borderRadiusProp.getName()).toBe('border-radius');
+  });
+});

--- a/test/editor/properties/img-fluid-prop.test.ts
+++ b/test/editor/properties/img-fluid-prop.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import ImgFluidProp from '@/editor/properties/ImgFluidProp.ts';
+
+describe('Border Radius prop test', () => {
+  it('Correct class creation', () => {
+    const imgFluidProp = new ImgFluidProp('value');
+
+    expect(imgFluidProp.value).toBe('value');
+    expect(imgFluidProp.defaultValue).toBe('imgFluid');
+    expect(imgFluidProp.description).toBe('___');
+    expect(imgFluidProp.title).toBe('___');
+    expect(imgFluidProp.availableValues).toStrictEqual({
+      imgFluid: 'img-fluid',
+    });
+    expect(ImgFluidProp.name).toBe('img-fluid');
+  });
+
+  it('Correct name getter', () => {
+    const imgFluidProp = new ImgFluidProp('value');
+
+    expect(imgFluidProp.getName()).toBe('img-fluid');
+  });
+});

--- a/test/editor/properties/link/link-opacity-prop.test.ts
+++ b/test/editor/properties/link/link-opacity-prop.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import LinkOpacityProp from '@/editor/properties/link/LinkOpacityProp.ts';
+
+describe('Link opacity prop test', () => {
+  it('Correct class creation', () => {
+    const linkOpacityProp = new LinkOpacityProp('value');
+
+    expect(linkOpacityProp.value).toBe('value');
+    expect(linkOpacityProp.defaultValue).toBe('opacity100');
+    expect(linkOpacityProp.description).toBe('___');
+    expect(linkOpacityProp.title).toBe('___');
+    expect(linkOpacityProp.availableValues).toStrictEqual({
+      opacity10: 'link-opacity-10',
+      opacity25: 'link-opacity-25',
+      opacity50: 'link-opacity-50',
+      opacity75: 'link-opacity-75',
+      opacity100: 'link-opacity-100',
+      opacityHover10: 'link-opacity-10-hover',
+      opacityHover25: 'link-opacity-25-hover',
+      opacityHover50: 'link-opacity-50-hover',
+      opacityHover75: 'link-opacity-75-hover',
+      opacityHover100: 'link-opacity-100-hover',
+    });
+    expect(LinkOpacityProp.name).toBe('link-opacity');
+  });
+
+  it('Correct name getter', () => {
+    const linkOpacityProp = new LinkOpacityProp('value');
+
+    expect(linkOpacityProp.getName()).toBe('link-opacity');
+  });
+});

--- a/test/editor/properties/link/link-underline-offset-prop.test.ts
+++ b/test/editor/properties/link/link-underline-offset-prop.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import LinkUnderlineOffsetProp from '@/editor/properties/link/LinkUnderlineOffsetProp.ts';
+
+describe('Link Underline Offset prop test', () => {
+  it('Correct class creation', () => {
+    const linkUnderlineOffsetProp = new LinkUnderlineOffsetProp('value');
+
+    expect(linkUnderlineOffsetProp.value).toBe('value');
+    expect(linkUnderlineOffsetProp.defaultValue).toBe('link-offset-1');
+    expect(linkUnderlineOffsetProp.description).toBe('___');
+    expect(linkUnderlineOffsetProp.title).toBe('___');
+    expect(linkUnderlineOffsetProp.availableValues).toStrictEqual({
+      one: 'link-offset-1',
+      two: 'link-offset-2',
+      three: 'link-offset-3',
+    });
+    expect(LinkUnderlineOffsetProp.name).toBe('link-offset');
+  });
+
+  it('Correct name getter', () => {
+    const linkUnderlineOffsetProp = new LinkUnderlineOffsetProp('value');
+
+    expect(linkUnderlineOffsetProp.getName()).toBe('link-offset');
+  });
+});

--- a/test/editor/properties/link/link-underline-opacity.test.ts
+++ b/test/editor/properties/link/link-underline-opacity.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import LinkUnderlineOpacity from '@/editor/properties/link/LinkUnderlineOpacity.ts';
+
+describe('Link Underline Opacity prop test', () => {
+  it('Correct class creation', () => {
+    const linkUnderlineOpacity = new LinkUnderlineOpacity('value');
+
+    expect(linkUnderlineOpacity.value).toBe('value');
+    expect(linkUnderlineOpacity.defaultValue).toBe('opacity100');
+    expect(linkUnderlineOpacity.description).toBe('___');
+    expect(linkUnderlineOpacity.title).toBe('___');
+    expect(linkUnderlineOpacity.availableValues).toStrictEqual({
+      opacity0: 'link-underline-opacity-0',
+      opacity10: 'link-underline-opacity-10',
+      opacity25: 'link-underline-opacity-25',
+      opacity50: 'link-underline-opacity-50',
+      opacity75: 'link-underline-opacity-75',
+      opacity100: 'link-underline-opacity-100',
+    });
+    expect(LinkUnderlineOpacity.name).toBe('link-underline-opacity');
+  });
+
+  it('Correct name getter', () => {
+    const linkUnderlineOpacity = new LinkUnderlineOpacity('value');
+
+    expect(linkUnderlineOpacity.getName()).toBe('link-underline-opacity');
+  });
+});

--- a/test/editor/properties/link/link-underline-prop.test.ts
+++ b/test/editor/properties/link/link-underline-prop.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import LinkUnderlineProp from '@/editor/properties/link/LinkUnderlineProp.ts';
+
+describe('Link Underline prop test', () => {
+  it('Correct class creation', () => {
+    const linkUnderlineProp = new LinkUnderlineProp('value');
+
+    expect(linkUnderlineProp.value).toBe('value');
+    expect(linkUnderlineProp.defaultValue).toBe('primary');
+    expect(linkUnderlineProp.description).toBe('___');
+    expect(linkUnderlineProp.title).toBe('___');
+    expect(linkUnderlineProp.availableValues).toStrictEqual({
+      primary: 'link-underline-primary',
+      secondary: 'link-underline-secondary',
+      success: 'link-underline-success',
+      danger: 'link-underline-danger',
+      warning: 'link-underline-warning',
+      info: 'link-underline-info',
+      light: 'link-underline-light',
+      dark: 'link-underline-dark',
+    });
+    expect(LinkUnderlineProp.name).toBe('link-underline');
+  });
+
+  it('Correct name getter', () => {
+    const linkUnderlineProp = new LinkUnderlineProp('value');
+
+    expect(linkUnderlineProp.getName()).toBe('link-underline');
+  });
+});

--- a/test/editor/properties/text/font-weight-prop.test.ts
+++ b/test/editor/properties/text/font-weight-prop.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import FontWeightProp from '@/editor/properties/text/FontWeightProp.ts';
+
+describe('Font weight prop test', () => {
+  it('Correct class creation', () => {
+    const fontWeightProp = new FontWeightProp('value');
+
+    expect(fontWeightProp.value).toBe('value');
+    expect(fontWeightProp.defaultValue).toBe('normal');
+    expect(fontWeightProp.description).toBe('___');
+    expect(fontWeightProp.title).toBe('___');
+    expect(fontWeightProp.availableValues).toStrictEqual({
+      bold: 'fw-bold',
+      bolder: 'fw-bolder',
+      semibold: 'fw-semibold',
+      medium: 'fw-medium',
+      normal: 'fw-normal',
+      light: 'fw-light',
+      lighter: 'fw-lighter',
+      italic: 'fst-italic',
+      normal: 'fst-normal',
+    });
+    expect(FontWeightProp.name).toBe('fw');
+  });
+
+  it('Correct name getter', () => {
+    const fontWeightProp = new FontWeightProp('value');
+
+    expect(fontWeightProp.getName()).toBe('fw');
+  });
+});

--- a/test/editor/properties/text/inline-text-props.test.ts
+++ b/test/editor/properties/text/inline-text-props.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import InlineTextProps from '@/editor/properties/text/InlineTextProps.ts';
+
+describe('Inline text props test', () => {
+  it('Correct class creation', () => {
+    const itProps = new InlineTextProps(['mark', 'small']);
+
+    expect(itProps.values).toStrictEqual(['mark', 'small']);
+    expect(itProps.defaultValue).toBe('empty');
+    expect(itProps.description).toBe('___');
+    expect(itProps.title).toBe('___');
+    expect(itProps.availableValues).toStrictEqual({
+      empty: '',
+      mark: 'mark',
+      small: 'small',
+      textDecorationUnderline: 'text-decoration-underline',
+      textDecorationLineThrough: 'text-decoration-line-through',
+      textDecorationNone: 'text-decoration-none',
+    });
+    expect(InlineTextProps.name).toBe('inline-text');
+  });
+
+  it('Correct name getter', () => {
+    const itProps = new InlineTextProps(['mark', 'small']);
+    expect(itProps.getName()).toBe('inline-text');
+  });
+});

--- a/test/editor/properties/text/lead-paragraph-prop.test.ts
+++ b/test/editor/properties/text/lead-paragraph-prop.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import LeadParagraphProp from '@/editor/properties/text/LeadParagraphProp.ts';
+
+describe('Lead paragraph prop test', () => {
+  it('Correct class creation', () => {
+    const leadParagraphProp = new LeadParagraphProp('value');
+
+    expect(leadParagraphProp.value).toBe('value');
+    expect(leadParagraphProp.defaultValue).toBe('lead');
+    expect(leadParagraphProp.description).toBe('___');
+    expect(leadParagraphProp.title).toBe('___');
+    expect(leadParagraphProp.availableValues).toStrictEqual({
+      lead: 'lead',
+    });
+    expect(LeadParagraphProp.name).toBe('lead-paragraph');
+  });
+
+  it('Correct name getter', () => {
+    const leadParagraphProp = new LeadParagraphProp('value');
+
+    expect(leadParagraphProp.getName()).toBe('lead-paragraph');
+  });
+});

--- a/test/editor/properties/text/line-height-prop.test.ts
+++ b/test/editor/properties/text/line-height-prop.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import LineHeightProp from '@/editor/properties/text/LineHeightProp.ts';
+
+describe('Line Height prop test', () => {
+  it('Correct class creation', () => {
+    const lineHeightProp = new LineHeightProp('value');
+
+    expect(lineHeightProp.value).toBe('value');
+    expect(lineHeightProp.defaultValue).toBe('base');
+    expect(lineHeightProp.description).toBe('___');
+    expect(lineHeightProp.title).toBe('___');
+    expect(lineHeightProp.availableValues).toStrictEqual({
+      one: 'lh-1',
+      small: 'lh-sm',
+      base: 'lh-base',
+      large: 'lh-lg',
+    });
+    expect(LineHeightProp.name).toBe('lh');
+  });
+
+  it('Correct name getter', () => {
+    const leadParagraphProp = new LineHeightProp('value');
+
+    expect(leadParagraphProp.getName()).toBe('lh');
+  });
+});

--- a/test/editor/properties/text/list-inline-prop.test.ts
+++ b/test/editor/properties/text/list-inline-prop.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import ListInlineProp from '@/editor/properties/text/ListInlineProp.ts';
+
+describe('List Inline prop test', () => {
+  it('Correct class creation', () => {
+    const listInlineProp = new ListInlineProp('value');
+
+    expect(listInlineProp.value).toBe('value');
+    expect(listInlineProp.defaultValue).toBe('inline');
+    expect(listInlineProp.description).toBe('___');
+    expect(listInlineProp.title).toBe('___');
+    expect(listInlineProp.availableValues).toStrictEqual({
+      inline: 'list-inline',
+      item: 'list-inline-item',
+    });
+    expect(ListInlineProp.name).toBe('list-inline');
+  });
+
+  it('Correct name getter', () => {
+    const listInlineProp = new ListInlineProp('value');
+
+    expect(listInlineProp.getName()).toBe('list-inline');
+  });
+});

--- a/test/editor/properties/text/list-unsyled-prop.test.ts
+++ b/test/editor/properties/text/list-unsyled-prop.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import ListUnstyledProp from '@/editor/properties/text/ListUnstyledProp.ts';
+
+describe('List Unsyled prop test', () => {
+  it('Correct class creation', () => {
+    const listUnstyledProp = new ListUnstyledProp('value');
+
+    expect(listUnstyledProp.value).toBe('value');
+    expect(listUnstyledProp.defaultValue).toBe('unstyled');
+    expect(listUnstyledProp.description).toBe('___');
+    expect(listUnstyledProp.title).toBe('___');
+    expect(listUnstyledProp.availableValues).toStrictEqual({
+      unsyled: 'list-unstyled',
+    });
+    expect(ListUnstyledProp.name).toBe('list-unstyled');
+  });
+
+  it('Correct name getter', () => {
+    const listUnstyledProp = new ListUnstyledProp('value');
+
+    expect(listUnstyledProp.getName()).toBe('list-unstyled');
+  });
+});

--- a/test/editor/properties/text/mono-space-prop.test.ts
+++ b/test/editor/properties/text/mono-space-prop.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import MonoSpaceProp from '@/editor/properties/text/MonoSpaceProp.ts';
+
+describe('Monospace prop test', () => {
+  it('Correct class creation', () => {
+    const monoSpaceProp = new MonoSpaceProp('value');
+
+    expect(monoSpaceProp.value).toBe('value');
+    expect(monoSpaceProp.defaultValue).toBe('monospace');
+    expect(monoSpaceProp.description).toBe('___');
+    expect(monoSpaceProp.title).toBe('___');
+    expect(monoSpaceProp.availableValues).toStrictEqual({
+      monospace: 'font-monospace',
+    });
+    expect(MonoSpaceProp.name).toBe('font-monospace');
+  });
+
+  it('Correct name getter', () => {
+    const monoSpaceProp = new MonoSpaceProp('value');
+
+    expect(monoSpaceProp.getName()).toBe('font-monospace');
+  });
+});

--- a/test/editor/properties/text/text-align-prop.test.ts
+++ b/test/editor/properties/text/text-align-prop.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import TextAlignProp from '@/editor/properties/text/TextAlignProp.ts';
+
+describe('Text Align prop test', () => {
+  it('Correct class creation', () => {
+    const textAlignProp = new TextAlignProp('value');
+
+    expect(textAlignProp.value).toBe('value');
+    expect(textAlignProp.defaultValue).toBe('start');
+    expect(textAlignProp.description).toBe('___');
+    expect(textAlignProp.title).toBe('___');
+    expect(textAlignProp.availableValues).toStrictEqual({
+      start: 'text-start',
+      end: 'text-end',
+      center: 'text-center',
+    });
+    expect(TextAlignProp.name).toBe('text-align');
+  });
+
+  it('Correct name getter', () => {
+    const textAlignProp = new TextAlignProp('value');
+
+    expect(textAlignProp.getName()).toBe('text-align');
+  });
+});

--- a/test/editor/properties/text/text-transform-prop.test.ts
+++ b/test/editor/properties/text/text-transform-prop.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import TextTransformProp from '@/editor/properties/text/TextTransformProp.ts';
+
+describe('Text transform prop test', () => {
+  it('Correct class creation', () => {
+    const textTransformProp = new TextTransformProp('value');
+
+    expect(textTransformProp.value).toBe('value');
+    expect(textTransformProp.defaultValue).toBe('text-capitalize');
+    expect(textTransformProp.description).toBe('___');
+    expect(textTransformProp.title).toBe('___');
+    expect(textTransformProp.availableValues).toStrictEqual({
+      lowercase: 'text-lowercase',
+      uppercase: 'text-uppercase',
+      capitalize: 'text-capitalize',
+    });
+    expect(TextTransformProp.name).toBe('text-transform');
+  });
+
+  it('Correct name getter', () => {
+    const textTransformProp = new TextTransformProp('value');
+
+    expect(textTransformProp.getName()).toBe('text-transform');
+  });
+});


### PR DESCRIPTION
### Описание изменений
Добавлены новые property  для текста (font-weight, font-style, inline-text, text-decoration, lead, line-height, list-inline, list-inline-item, list-unstyled, font-monospace, text-align, text-transform), ссылок (link-opacity, link-underline, link-underline-offset, link-link-underline-opacity), для изображения (img-fluid), общий property: border-radius.

### Тип изменений
- [x] Новая функциональность
- [ ] Исправление ошибок
- [ ] Улучшение существующего кода
- [ ] Другие изменения

### Тестирование
Все новые Property были покрыты тестами

