### PR TITLE
feat(core): web socket API model util

### DIFF
--- a/src/utils/ws-model.util.ts
+++ b/src/utils/ws-model.util.ts
@@ -1,122 +1,121 @@
-import appConf from "@/api/conf/app.conf";
-import TokenUtil from "./token.util";
+import appConf from '@/api/conf/app.conf';
+import TokenUtil from './token.util';
 import ApiModelUtil from './api-model.util';
 
 export default class WsModelUtil {
-    protected actions: Record<string, Function> = {}
-    protected ws: WebSocket
-    protected initialized: boolean = false;
-    private lastSent: any;
-    private onRefresh: boolean = false;
-    public ON_OPEN_ACTION = "_system_on_open"
-    public ON_ERROR_ACTION = "_system_on_error"
-    public ON_CLOSE_ACTION = "_system_on_close"
-    public RESPONSE_HANDLER = "_system_response_handler"
+  protected actions: Record<string, Function> = {};
+  protected ws: WebSocket;
+  protected initialized: boolean = false;
+  private lastSent: any;
+  private onRefresh: boolean = false;
+  public ON_OPEN_ACTION = '_system_on_open';
+  public ON_ERROR_ACTION = '_system_on_error';
+  public ON_CLOSE_ACTION = '_system_on_close';
+  public RESPONSE_HANDLER = '_system_response_handler';
 
-    constructor(
-        public url: string,
-        public autoRestart: boolean
-    ) { }
+  constructor(
+    public url: string,
+    public autoRestart: boolean,
+  ) {}
 
-    init() {
-        if (this.initialized) return;
-        this.ws = new WebSocket(`${appConf.proto}://${appConf.endpoint}/${this.url}`);
+  init() {
+    if (this.initialized) return;
+    this.ws = new WebSocket(
+      `${appConf.proto}://${appConf.endpoint}/${this.url}`,
+    );
 
-        this.ws.onopen = this.onOpen;
-        this.ws.onerror = this.onError;
-        this.ws.onclose = this.onClose;
-        this.ws.onmessage = this.onMessage;
-    
-        this.initialized = true;
+    this.ws.onopen = this.onOpen;
+    this.ws.onerror = this.onError;
+    this.ws.onclose = this.onClose;
+    this.ws.onmessage = this.onMessage;
+
+    this.initialized = true;
+  }
+
+  protected onOpen() {
+    this.actions[this.ON_OPEN_ACTION]();
+  }
+
+  close() {
+    if (!this.ws.CLOSED) this.ws.close();
+    this.initialized = false;
+  }
+
+  restart() {
+    this.close();
+    this.init();
+  }
+
+  register(actionName: string, handler: Function) {
+    this.actions[actionName] = handler;
+  }
+
+  registerOnOpen(handler: Function) {
+    this.actions[this.ON_OPEN_ACTION] = handler;
+  }
+
+  registerOnError(handler: Function) {
+    this.actions[this.ON_ERROR_ACTION] = handler;
+  }
+
+  registerOnClose(handler: Function) {
+    this.actions[this.ON_CLOSE_ACTION] = handler;
+  }
+
+  registerResponseHandler(handler: Function) {
+    this.actions[this.RESPONSE_HANDLER] = handler;
+  }
+
+  send(route: string, message: any) {
+    const authData = TokenUtil.getAccess();
+    this.lastSent = {
+      route,
+      data: message,
+    };
+    this.ws.send(
+      JSON.stringify({
+        ...this.lastSent,
+        headers: {
+          Authorization: authData,
+        },
+      }),
+    );
+  }
+
+  private async refreshAndExecuteLast() {
+    const apiModel = new ApiModelUtil('');
+    await apiModel.refresh();
+    this.send(this.lastSent.route, this.lastSent.data);
+  }
+
+  protected onClose() {
+    if (this.actions[this.ON_CLOSE_ACTION])
+      this.actions[this.ON_CLOSE_ACTION]();
+
+    if (this.autoRestart) this.restart();
+  }
+
+  protected onError(err) {
+    if (this.actions[this.ON_ERROR_ACTION])
+      this.actions[this.ON_ERROR_ACTION](err);
+
+    if (this.autoRestart) this.restart();
+    else this.close();
+  }
+
+  protected onMessage(message) {
+    const data = JSON.parse(message);
+    if (data.type) {
+      if (this.actions[data.type]) this.actions[data.type](data);
+    } else {
+      if (data.status && data.status == 403 && !this.onRefresh) {
+        this.onRefresh = true;
+        this.refreshAndExecuteLast();
+      } else {
+        this.onRefresh = false;
+        if (this.actions[this.RESPONSE_HANDLER])
+          this.actions[this.RESPONSE_HANDLER](data);
+      }
     }
-
-    protected onOpen() {
-        this.actions[this.ON_OPEN_ACTION]()
-    }
-
-    close() {
-        if (!this.ws.CLOSED)
-            this.ws.close()
-        this.initialized = false;
-    }
-
-    restart() {
-        this.close();
-        this.init();
-    }
-
-    register(actionName: string, handler: Function) {
-        this.actions[actionName] = handler;
-    }
-
-    registerOnOpen(handler: Function) {
-        this.actions[this.ON_OPEN_ACTION] = handler;
-    }
-
-    registerOnError(handler: Function) {
-        this.actions[this.ON_ERROR_ACTION] = handler;
-    }
-
-    registerOnClose(handler: Function) {
-        this.actions[this.ON_CLOSE_ACTION] = handler;
-    }
-
-    registerResponseHandler(handler: Function) {
-        this.actions[this.RESPONSE_HANDLER] = handler
-    }
-
-    send(route: string, message: any) {
-        const authData = TokenUtil.getAccess()
-        this.lastSent = {
-            route,
-            data: message
-        }
-        this.ws.send(JSON.stringify({
-            ...this.lastSent, 
-            headers: {
-                Authorization: authData
-            },
-        }))
-    }
-
-    private async refreshAndExecuteLast() {
-        const apiModel = new ApiModelUtil("");
-        await apiModel.refresh()
-        this.send(this.lastSent.route, this.lastSent.data)
-    }
-
-    protected onClose() {
-        if (this.actions[this.ON_CLOSE_ACTION])
-            this.actions[this.ON_CLOSE_ACTION]();
-
-        if (this.autoRestart)
-            this.restart();
-    }
-
-    protected onError(err) {
-        if (this.actions[this.ON_ERROR_ACTION])
-            this.actions[this.ON_ERROR_ACTION](err);
-
-        if (this.autoRestart)
-            this.restart()
-        else
-            this.close();
-    }
-
-    protected onMessage(message) {
-        const data = JSON.parse(message);
-        if (data.type) {
-            if (this.actions[data.type])
-                this.actions[data.type](data);
-        } else {
-            if (data.status && data.status == 403 && !this.onRefresh) {
-                this.onRefresh = true;
-                this.refreshAndExecuteLast();
-            } else {
-                this.onRefresh = false;
-                if (this.actions[this.RESPONSE_HANDLER])
-                    this.actions[this.RESPONSE_HANDLER](data);
-            }
-        }
-    }
+  }
 }

--- a/src/utils/ws-model.util.ts
+++ b/src/utils/ws-model.util.ts
@@ -1,0 +1,122 @@
+import appConf from "@/api/conf/app.conf";
+import TokenUtil from "./token.util";
+import ApiModelUtil from './api-model.util';
+
+export default class WsModelUtil {
+    protected actions: Record<string, Function> = {}
+    protected ws: WebSocket
+    protected initialized: boolean = false;
+    private lastSent: any;
+    private onRefresh: boolean = false;
+    public ON_OPEN_ACTION = "_system_on_open"
+    public ON_ERROR_ACTION = "_system_on_error"
+    public ON_CLOSE_ACTION = "_system_on_close"
+    public RESPONSE_HANDLER = "_system_response_handler"
+
+    constructor(
+        public url: string,
+        public autoRestart: boolean
+    ) { }
+
+    init() {
+        if (this.initialized) return;
+        this.ws = new WebSocket(`${appConf.proto}://${appConf.endpoint}/${this.url}`);
+
+        this.ws.onopen = this.onOpen;
+        this.ws.onerror = this.onError;
+        this.ws.onclose = this.onClose;
+        this.ws.onmessage = this.onMessage;
+    
+        this.initialized = true;
+    }
+
+    protected onOpen() {
+        this.actions[this.ON_OPEN_ACTION]()
+    }
+
+    close() {
+        if (!this.ws.CLOSED)
+            this.ws.close()
+        this.initialized = false;
+    }
+
+    restart() {
+        this.close();
+        this.init();
+    }
+
+    register(actionName: string, handler: Function) {
+        this.actions[actionName] = handler;
+    }
+
+    registerOnOpen(handler: Function) {
+        this.actions[this.ON_OPEN_ACTION] = handler;
+    }
+
+    registerOnError(handler: Function) {
+        this.actions[this.ON_ERROR_ACTION] = handler;
+    }
+
+    registerOnClose(handler: Function) {
+        this.actions[this.ON_CLOSE_ACTION] = handler;
+    }
+
+    registerResponseHandler(handler: Function) {
+        this.actions[this.RESPONSE_HANDLER] = handler
+    }
+
+    send(route: string, message: any) {
+        const authData = TokenUtil.getAccess()
+        this.lastSent = {
+            route,
+            data: message
+        }
+        this.ws.send(JSON.stringify({
+            ...this.lastSent, 
+            headers: {
+                Authorization: authData
+            },
+        }))
+    }
+
+    private async refreshAndExecuteLast() {
+        const apiModel = new ApiModelUtil("");
+        await apiModel.refresh()
+        this.send(this.lastSent.route, this.lastSent.data)
+    }
+
+    protected onClose() {
+        if (this.actions[this.ON_CLOSE_ACTION])
+            this.actions[this.ON_CLOSE_ACTION]();
+
+        if (this.autoRestart)
+            this.restart();
+    }
+
+    protected onError(err) {
+        if (this.actions[this.ON_ERROR_ACTION])
+            this.actions[this.ON_ERROR_ACTION](err);
+
+        if (this.autoRestart)
+            this.restart()
+        else
+            this.close();
+    }
+
+    protected onMessage(message) {
+        const data = JSON.parse(message);
+        if (data.type) {
+            if (this.actions[data.type])
+                this.actions[data.type](data);
+        } else {
+            if (data.status && data.status == 403 && !this.onRefresh) {
+                this.onRefresh = true;
+                this.refreshAndExecuteLast();
+            } else {
+                this.onRefresh = false;
+                if (this.actions[this.RESPONSE_HANDLER])
+                    this.actions[this.RESPONSE_HANDLER](data);
+            }
+        }
+    }
+}

--- a/test/util/ws-util.test.ts
+++ b/test/util/ws-util.test.ts
@@ -1,0 +1,270 @@
+// @ts-nocheck
+import { describe, beforeEach, it, expect, vi } from 'vitest';
+import WsModelUtil from '@/utils/ws-model.util';
+import TokenUtil from '@/utils/token.util';
+import ApiModelUtil from '@/utils/api-model.util';
+
+class WebSocketMock {}
+
+class ApiModelUtilMock {
+    static RefreshStatic = vi.fn()
+
+    public refresh = ApiModelUtilMock.RefreshStatic; 
+}
+
+vi.mock('@/utils/token.util.ts', () => ({
+    default: {
+        getAccess: vi.fn(() => "token")
+    }
+}))
+
+vi.mock('@/utils/api-model.util.ts', () => {
+    class ApiModelUtilMock {
+        static RefreshStatic = vi.fn()
+
+        public refresh = ApiModelUtilMock.RefreshStatic; 
+    }
+
+    return {
+        default: ApiModelUtilMock
+    }
+})
+
+
+describe('WsModelUtil tests', () => {
+    let wsModelUtil: WsModelUtil;
+    beforeEach(() => {
+        vi.stubGlobal("WebSocket", WebSocketMock)
+        wsModelUtil = new WsModelUtil('test', true);
+    })
+
+    it('Test constructing', () => {
+        expect(wsModelUtil.autoRestart).toBe(true)
+        expect(wsModelUtil.url).toBe("test")
+    })
+
+    it('Test initilization', () => {
+        wsModelUtil.onOpen = "onopen"
+        wsModelUtil.onError = "onerror"
+        wsModelUtil.onClose = "onclose"
+        wsModelUtil.onMessage = "onmessage"
+        
+        wsModelUtil.init()
+        
+        expect(wsModelUtil.initialized).toBe(true)
+        expect(wsModelUtil.ws.onopen).toBe(wsModelUtil.onOpen)
+        expect(wsModelUtil.ws.onerror).toBe(wsModelUtil.onError)
+        expect(wsModelUtil.ws.onclose).toBe(wsModelUtil.onClose)
+        expect(wsModelUtil.ws.onmessage).toBe(wsModelUtil.onMessage)
+    })
+
+    it('Test onOpen', () => {
+        wsModelUtil.actions[wsModelUtil.ON_OPEN_ACTION] = vi.fn()
+
+        wsModelUtil.onOpen()
+
+        expect(wsModelUtil.actions[wsModelUtil.ON_OPEN_ACTION]).toBeCalled()
+    })
+
+    describe('Test closing', () => {
+        it('if closed', () => {
+            wsModelUtil.ws = {
+                CLOSED: true,
+                close: vi.fn()
+            }
+
+            wsModelUtil.close()
+
+            expect(wsModelUtil.initialized).toBe(false)
+            expect(wsModelUtil.ws.close).toBeCalledTimes(0)
+        })
+
+        it('if open', () => {
+            wsModelUtil.ws = {
+                CLOSED: false,
+                close: vi.fn()
+            }
+
+            wsModelUtil.close()
+
+            expect(wsModelUtil.initialized).toBe(false)
+            expect(wsModelUtil.ws.close).toBeCalledTimes(1)
+        })
+    })
+
+    it('test restart', () => {
+        wsModelUtil.close = vi.fn()
+        wsModelUtil.init = vi.fn()
+
+        wsModelUtil.restart()
+
+        expect(wsModelUtil.close).toBeCalledTimes(1)
+        expect(wsModelUtil.init).toBeCalledTimes(1)
+    })
+
+    describe('handlers` registerators test', () => {
+        it('unified', () => {
+            wsModelUtil.actions = {}
+            wsModelUtil.register('action', "func")
+    
+            expect(Object.keys(wsModelUtil.actions)).toContain('action')
+            expect(wsModelUtil.actions['action']).toBe('func')
+        })
+    
+        it('onopen', () => {
+            wsModelUtil.actions = {}
+            wsModelUtil.registerOnOpen("func")
+    
+            expect(Object.keys(wsModelUtil.actions)).toContain(wsModelUtil.ON_OPEN_ACTION)
+            expect(wsModelUtil.actions[wsModelUtil.ON_OPEN_ACTION]).toBe('func')
+        })
+
+        it('onerror', () => {
+            wsModelUtil.actions = {}
+            wsModelUtil.registerOnError("func")
+    
+            expect(Object.keys(wsModelUtil.actions)).toContain(wsModelUtil.ON_ERROR_ACTION)
+            expect(wsModelUtil.actions[wsModelUtil.ON_ERROR_ACTION]).toBe('func')
+        })
+
+        it('onclose', () => {
+            wsModelUtil.actions = {}
+            wsModelUtil.registerOnClose("func")
+    
+            expect(Object.keys(wsModelUtil.actions)).toContain(wsModelUtil.ON_CLOSE_ACTION)
+            expect(wsModelUtil.actions[wsModelUtil.ON_CLOSE_ACTION]).toBe('func')
+        })
+
+        it('response', () => {
+            wsModelUtil.actions = {}
+            wsModelUtil.registerResponseHandler("func")
+    
+            expect(Object.keys(wsModelUtil.actions)).toContain(wsModelUtil.RESPONSE_HANDLER)
+            expect(wsModelUtil.actions[wsModelUtil.RESPONSE_HANDLER]).toBe('func')
+        })
+    })
+
+    it('test sending', () => {
+        wsModelUtil.ws = {
+            send: vi.fn()
+        }
+        const lastSent = { 
+            route: 'route',
+            data: 'message',
+        }
+        
+        wsModelUtil.send('route', 'message')
+
+        expect(wsModelUtil.lastSent).toEqual(lastSent)
+        expect(TokenUtil.getAccess).toBeCalled()
+        expect(wsModelUtil.ws.send).toBeCalledWith(JSON.stringify({
+            ...lastSent,
+            headers: {
+                Authorization: 'token'
+            }
+        }))
+    })
+
+    it('test refresh and execute last', async () => {
+        wsModelUtil.lastSent = { route: 'test', data: 'data' }
+        wsModelUtil.send = vi.fn()
+
+        await wsModelUtil.refreshAndExecuteLast()
+
+        expect(ApiModelUtil.RefreshStatic).toBeCalled()
+        expect(wsModelUtil.send).toBeCalledWith('test', 'data')
+    })
+
+    describe('Test handlers', () => {
+        beforeEach(() => {
+            wsModelUtil.actions[wsModelUtil.ON_CLOSE_ACTION] = vi.fn()
+            wsModelUtil.actions[wsModelUtil.ON_ERROR_ACTION] = vi.fn()
+        })
+
+        describe('on close', () => {
+            it('with autorestart', () => {
+                wsModelUtil.autoRestart = true
+                wsModelUtil.restart = vi.fn()
+
+                wsModelUtil.onClose();
+
+                expect(wsModelUtil.actions[wsModelUtil.ON_CLOSE_ACTION]).toBeCalled()
+                expect(wsModelUtil.restart).toBeCalled()
+            })
+
+            it('without autorestart', () => {
+                wsModelUtil.autoRestart = false
+                wsModelUtil.restart = vi.fn()
+
+                wsModelUtil.onClose();
+
+                expect(wsModelUtil.actions[wsModelUtil.ON_CLOSE_ACTION]).toBeCalled()
+                expect(wsModelUtil.restart).toBeCalledTimes(0)
+            })
+        })
+
+        describe('on error', () => {
+            beforeEach(() => {
+                wsModelUtil.restart = vi.fn()
+                wsModelUtil.close = vi.fn()
+            })
+            it('with autorestart', () => {
+                wsModelUtil.autoRestart = true
+
+                wsModelUtil.onError();
+
+                expect(wsModelUtil.actions[wsModelUtil.ON_ERROR_ACTION]).toBeCalled()
+                expect(wsModelUtil.restart).toBeCalled()
+                expect(wsModelUtil.close).toBeCalledTimes(0)
+            })
+
+            it('without autorestart', () => {
+                wsModelUtil.autoRestart = false
+                wsModelUtil.restart = vi.fn()
+
+                wsModelUtil.onError();
+
+                expect(wsModelUtil.actions[wsModelUtil.ON_ERROR_ACTION]).toBeCalled()
+                expect(wsModelUtil.close).toBeCalled()
+                expect(wsModelUtil.restart).toBeCalledTimes(0)
+            })
+        })
+
+        describe('on message', () => {
+            it('with type', () => {
+                const type = 'type'
+                const message = JSON.stringify({type})
+                wsModelUtil.actions[type] = vi.fn()
+
+                wsModelUtil.onMessage(message)
+
+                expect(wsModelUtil.actions[type]).toBeCalledWith({type})
+            })
+
+            describe('without type', () => {
+                it('success or no status', () => {
+                    wsModelUtil.onRefresh = true;
+                    wsModelUtil.actions[wsModelUtil.RESPONSE_HANDLER] = vi.fn()
+                    const message = JSON.stringify({msg: 'msg'})
+                
+                    
+                    wsModelUtil.onMessage(message)
+
+                    expect(wsModelUtil.onRefresh).toBe(false)
+                    expect(wsModelUtil.actions[wsModelUtil.RESPONSE_HANDLER]).toBeCalledWith({msg: 'msg'})
+                })
+
+                it('403 status (not in refresh)', () => {
+                    wsModelUtil.onRefresh = false;
+                    wsModelUtil.refreshAndExecuteLast = vi.fn()
+                    const message = JSON.stringify({status: 403})
+
+                    wsModelUtil.onMessage(message)
+
+                    expect(wsModelUtil.refreshAndExecuteLast).toBeCalled()
+                    expect(wsModelUtil.onRefresh).toBe(true)
+                })
+            })
+        })
+    })
+})

--- a/test/util/ws-util.test.ts
+++ b/test/util/ws-util.test.ts
@@ -6,265 +6,269 @@ import ApiModelUtil from '@/utils/api-model.util';
 
 class WebSocketMock {}
 
-class ApiModelUtilMock {
-    static RefreshStatic = vi.fn()
-
-    public refresh = ApiModelUtilMock.RefreshStatic; 
-}
-
 vi.mock('@/utils/token.util.ts', () => ({
-    default: {
-        getAccess: vi.fn(() => "token")
-    }
-}))
+  default: {
+    getAccess: vi.fn(() => 'token'),
+  },
+}));
 
 vi.mock('@/utils/api-model.util.ts', () => {
-    class ApiModelUtilMock {
-        static RefreshStatic = vi.fn()
+  class ApiModelUtilMock {
+    static RefreshStatic = vi.fn();
 
-        public refresh = ApiModelUtilMock.RefreshStatic; 
-    }
+    public refresh = ApiModelUtilMock.RefreshStatic;
+  }
 
-    return {
-        default: ApiModelUtilMock
-    }
-})
-
+  return {
+    default: ApiModelUtilMock,
+  };
+});
 
 describe('WsModelUtil tests', () => {
-    let wsModelUtil: WsModelUtil;
+  let wsModelUtil: WsModelUtil;
+  beforeEach(() => {
+    vi.stubGlobal('WebSocket', WebSocketMock);
+    wsModelUtil = new WsModelUtil('test', true);
+  });
+
+  it('Test constructing', () => {
+    expect(wsModelUtil.autoRestart).toBe(true);
+    expect(wsModelUtil.url).toBe('test');
+  });
+
+  it('Test initilization', () => {
+    wsModelUtil.onOpen = 'onopen';
+    wsModelUtil.onError = 'onerror';
+    wsModelUtil.onClose = 'onclose';
+    wsModelUtil.onMessage = 'onmessage';
+
+    wsModelUtil.init();
+
+    expect(wsModelUtil.initialized).toBe(true);
+    expect(wsModelUtil.ws.onopen).toBe(wsModelUtil.onOpen);
+    expect(wsModelUtil.ws.onerror).toBe(wsModelUtil.onError);
+    expect(wsModelUtil.ws.onclose).toBe(wsModelUtil.onClose);
+    expect(wsModelUtil.ws.onmessage).toBe(wsModelUtil.onMessage);
+  });
+
+  it('Test onOpen', () => {
+    wsModelUtil.actions[wsModelUtil.ON_OPEN_ACTION] = vi.fn();
+
+    wsModelUtil.onOpen();
+
+    expect(wsModelUtil.actions[wsModelUtil.ON_OPEN_ACTION]).toBeCalled();
+  });
+
+  describe('Test closing', () => {
+    it('if closed', () => {
+      wsModelUtil.ws = {
+        CLOSED: true,
+        close: vi.fn(),
+      };
+
+      wsModelUtil.close();
+
+      expect(wsModelUtil.initialized).toBe(false);
+      expect(wsModelUtil.ws.close).toBeCalledTimes(0);
+    });
+
+    it('if open', () => {
+      wsModelUtil.ws = {
+        CLOSED: false,
+        close: vi.fn(),
+      };
+
+      wsModelUtil.close();
+
+      expect(wsModelUtil.initialized).toBe(false);
+      expect(wsModelUtil.ws.close).toBeCalledTimes(1);
+    });
+  });
+
+  it('test restart', () => {
+    wsModelUtil.close = vi.fn();
+    wsModelUtil.init = vi.fn();
+
+    wsModelUtil.restart();
+
+    expect(wsModelUtil.close).toBeCalledTimes(1);
+    expect(wsModelUtil.init).toBeCalledTimes(1);
+  });
+
+  describe('handlers` registerators test', () => {
+    it('unified', () => {
+      wsModelUtil.actions = {};
+      wsModelUtil.register('action', 'func');
+
+      expect(Object.keys(wsModelUtil.actions)).toContain('action');
+      expect(wsModelUtil.actions['action']).toBe('func');
+    });
+
+    it('onopen', () => {
+      wsModelUtil.actions = {};
+      wsModelUtil.registerOnOpen('func');
+
+      expect(Object.keys(wsModelUtil.actions)).toContain(
+        wsModelUtil.ON_OPEN_ACTION,
+      );
+      expect(wsModelUtil.actions[wsModelUtil.ON_OPEN_ACTION]).toBe('func');
+    });
+
+    it('onerror', () => {
+      wsModelUtil.actions = {};
+      wsModelUtil.registerOnError('func');
+
+      expect(Object.keys(wsModelUtil.actions)).toContain(
+        wsModelUtil.ON_ERROR_ACTION,
+      );
+      expect(wsModelUtil.actions[wsModelUtil.ON_ERROR_ACTION]).toBe('func');
+    });
+
+    it('onclose', () => {
+      wsModelUtil.actions = {};
+      wsModelUtil.registerOnClose('func');
+
+      expect(Object.keys(wsModelUtil.actions)).toContain(
+        wsModelUtil.ON_CLOSE_ACTION,
+      );
+      expect(wsModelUtil.actions[wsModelUtil.ON_CLOSE_ACTION]).toBe('func');
+    });
+
+    it('response', () => {
+      wsModelUtil.actions = {};
+      wsModelUtil.registerResponseHandler('func');
+
+      expect(Object.keys(wsModelUtil.actions)).toContain(
+        wsModelUtil.RESPONSE_HANDLER,
+      );
+      expect(wsModelUtil.actions[wsModelUtil.RESPONSE_HANDLER]).toBe('func');
+    });
+  });
+
+  it('test sending', () => {
+    wsModelUtil.ws = {
+      send: vi.fn(),
+    };
+    const lastSent = {
+      route: 'route',
+      data: 'message',
+    };
+
+    wsModelUtil.send('route', 'message');
+
+    expect(wsModelUtil.lastSent).toEqual(lastSent);
+    expect(TokenUtil.getAccess).toBeCalled();
+    expect(wsModelUtil.ws.send).toBeCalledWith(
+      JSON.stringify({
+        ...lastSent,
+        headers: {
+          Authorization: 'token',
+        },
+      }),
+    );
+  });
+
+  it('test refresh and execute last', async () => {
+    wsModelUtil.lastSent = { route: 'test', data: 'data' };
+    wsModelUtil.send = vi.fn();
+
+    await wsModelUtil.refreshAndExecuteLast();
+
+    expect(ApiModelUtil.RefreshStatic).toBeCalled();
+    expect(wsModelUtil.send).toBeCalledWith('test', 'data');
+  });
+
+  describe('Test handlers', () => {
     beforeEach(() => {
-        vi.stubGlobal("WebSocket", WebSocketMock)
-        wsModelUtil = new WsModelUtil('test', true);
-    })
+      wsModelUtil.actions[wsModelUtil.ON_CLOSE_ACTION] = vi.fn();
+      wsModelUtil.actions[wsModelUtil.ON_ERROR_ACTION] = vi.fn();
+    });
 
-    it('Test constructing', () => {
-        expect(wsModelUtil.autoRestart).toBe(true)
-        expect(wsModelUtil.url).toBe("test")
-    })
+    describe('on close', () => {
+      it('with autorestart', () => {
+        wsModelUtil.autoRestart = true;
+        wsModelUtil.restart = vi.fn();
 
-    it('Test initilization', () => {
-        wsModelUtil.onOpen = "onopen"
-        wsModelUtil.onError = "onerror"
-        wsModelUtil.onClose = "onclose"
-        wsModelUtil.onMessage = "onmessage"
-        
-        wsModelUtil.init()
-        
-        expect(wsModelUtil.initialized).toBe(true)
-        expect(wsModelUtil.ws.onopen).toBe(wsModelUtil.onOpen)
-        expect(wsModelUtil.ws.onerror).toBe(wsModelUtil.onError)
-        expect(wsModelUtil.ws.onclose).toBe(wsModelUtil.onClose)
-        expect(wsModelUtil.ws.onmessage).toBe(wsModelUtil.onMessage)
-    })
+        wsModelUtil.onClose();
 
-    it('Test onOpen', () => {
-        wsModelUtil.actions[wsModelUtil.ON_OPEN_ACTION] = vi.fn()
+        expect(wsModelUtil.actions[wsModelUtil.ON_CLOSE_ACTION]).toBeCalled();
+        expect(wsModelUtil.restart).toBeCalled();
+      });
 
-        wsModelUtil.onOpen()
+      it('without autorestart', () => {
+        wsModelUtil.autoRestart = false;
+        wsModelUtil.restart = vi.fn();
 
-        expect(wsModelUtil.actions[wsModelUtil.ON_OPEN_ACTION]).toBeCalled()
-    })
+        wsModelUtil.onClose();
 
-    describe('Test closing', () => {
-        it('if closed', () => {
-            wsModelUtil.ws = {
-                CLOSED: true,
-                close: vi.fn()
-            }
+        expect(wsModelUtil.actions[wsModelUtil.ON_CLOSE_ACTION]).toBeCalled();
+        expect(wsModelUtil.restart).toBeCalledTimes(0);
+      });
+    });
 
-            wsModelUtil.close()
+    describe('on error', () => {
+      beforeEach(() => {
+        wsModelUtil.restart = vi.fn();
+        wsModelUtil.close = vi.fn();
+      });
+      it('with autorestart', () => {
+        wsModelUtil.autoRestart = true;
 
-            expect(wsModelUtil.initialized).toBe(false)
-            expect(wsModelUtil.ws.close).toBeCalledTimes(0)
-        })
+        wsModelUtil.onError();
 
-        it('if open', () => {
-            wsModelUtil.ws = {
-                CLOSED: false,
-                close: vi.fn()
-            }
+        expect(wsModelUtil.actions[wsModelUtil.ON_ERROR_ACTION]).toBeCalled();
+        expect(wsModelUtil.restart).toBeCalled();
+        expect(wsModelUtil.close).toBeCalledTimes(0);
+      });
 
-            wsModelUtil.close()
+      it('without autorestart', () => {
+        wsModelUtil.autoRestart = false;
+        wsModelUtil.restart = vi.fn();
 
-            expect(wsModelUtil.initialized).toBe(false)
-            expect(wsModelUtil.ws.close).toBeCalledTimes(1)
-        })
-    })
+        wsModelUtil.onError();
 
-    it('test restart', () => {
-        wsModelUtil.close = vi.fn()
-        wsModelUtil.init = vi.fn()
+        expect(wsModelUtil.actions[wsModelUtil.ON_ERROR_ACTION]).toBeCalled();
+        expect(wsModelUtil.close).toBeCalled();
+        expect(wsModelUtil.restart).toBeCalledTimes(0);
+      });
+    });
 
-        wsModelUtil.restart()
+    describe('on message', () => {
+      it('with type', () => {
+        const type = 'type';
+        const message = JSON.stringify({ type });
+        wsModelUtil.actions[type] = vi.fn();
 
-        expect(wsModelUtil.close).toBeCalledTimes(1)
-        expect(wsModelUtil.init).toBeCalledTimes(1)
-    })
+        wsModelUtil.onMessage(message);
 
-    describe('handlers` registerators test', () => {
-        it('unified', () => {
-            wsModelUtil.actions = {}
-            wsModelUtil.register('action', "func")
-    
-            expect(Object.keys(wsModelUtil.actions)).toContain('action')
-            expect(wsModelUtil.actions['action']).toBe('func')
-        })
-    
-        it('onopen', () => {
-            wsModelUtil.actions = {}
-            wsModelUtil.registerOnOpen("func")
-    
-            expect(Object.keys(wsModelUtil.actions)).toContain(wsModelUtil.ON_OPEN_ACTION)
-            expect(wsModelUtil.actions[wsModelUtil.ON_OPEN_ACTION]).toBe('func')
-        })
+        expect(wsModelUtil.actions[type]).toBeCalledWith({ type });
+      });
 
-        it('onerror', () => {
-            wsModelUtil.actions = {}
-            wsModelUtil.registerOnError("func")
-    
-            expect(Object.keys(wsModelUtil.actions)).toContain(wsModelUtil.ON_ERROR_ACTION)
-            expect(wsModelUtil.actions[wsModelUtil.ON_ERROR_ACTION]).toBe('func')
-        })
+      describe('without type', () => {
+        it('success or no status', () => {
+          wsModelUtil.onRefresh = true;
+          wsModelUtil.actions[wsModelUtil.RESPONSE_HANDLER] = vi.fn();
+          const message = JSON.stringify({ msg: 'msg' });
 
-        it('onclose', () => {
-            wsModelUtil.actions = {}
-            wsModelUtil.registerOnClose("func")
-    
-            expect(Object.keys(wsModelUtil.actions)).toContain(wsModelUtil.ON_CLOSE_ACTION)
-            expect(wsModelUtil.actions[wsModelUtil.ON_CLOSE_ACTION]).toBe('func')
-        })
+          wsModelUtil.onMessage(message);
 
-        it('response', () => {
-            wsModelUtil.actions = {}
-            wsModelUtil.registerResponseHandler("func")
-    
-            expect(Object.keys(wsModelUtil.actions)).toContain(wsModelUtil.RESPONSE_HANDLER)
-            expect(wsModelUtil.actions[wsModelUtil.RESPONSE_HANDLER]).toBe('func')
-        })
-    })
+          expect(wsModelUtil.onRefresh).toBe(false);
+          expect(
+            wsModelUtil.actions[wsModelUtil.RESPONSE_HANDLER],
+          ).toBeCalledWith({ msg: 'msg' });
+        });
 
-    it('test sending', () => {
-        wsModelUtil.ws = {
-            send: vi.fn()
-        }
-        const lastSent = { 
-            route: 'route',
-            data: 'message',
-        }
-        
-        wsModelUtil.send('route', 'message')
+        it('403 status (not in refresh)', () => {
+          wsModelUtil.onRefresh = false;
+          wsModelUtil.refreshAndExecuteLast = vi.fn();
+          const message = JSON.stringify({ status: 403 });
 
-        expect(wsModelUtil.lastSent).toEqual(lastSent)
-        expect(TokenUtil.getAccess).toBeCalled()
-        expect(wsModelUtil.ws.send).toBeCalledWith(JSON.stringify({
-            ...lastSent,
-            headers: {
-                Authorization: 'token'
-            }
-        }))
-    })
+          wsModelUtil.onMessage(message);
 
-    it('test refresh and execute last', async () => {
-        wsModelUtil.lastSent = { route: 'test', data: 'data' }
-        wsModelUtil.send = vi.fn()
-
-        await wsModelUtil.refreshAndExecuteLast()
-
-        expect(ApiModelUtil.RefreshStatic).toBeCalled()
-        expect(wsModelUtil.send).toBeCalledWith('test', 'data')
-    })
-
-    describe('Test handlers', () => {
-        beforeEach(() => {
-            wsModelUtil.actions[wsModelUtil.ON_CLOSE_ACTION] = vi.fn()
-            wsModelUtil.actions[wsModelUtil.ON_ERROR_ACTION] = vi.fn()
-        })
-
-        describe('on close', () => {
-            it('with autorestart', () => {
-                wsModelUtil.autoRestart = true
-                wsModelUtil.restart = vi.fn()
-
-                wsModelUtil.onClose();
-
-                expect(wsModelUtil.actions[wsModelUtil.ON_CLOSE_ACTION]).toBeCalled()
-                expect(wsModelUtil.restart).toBeCalled()
-            })
-
-            it('without autorestart', () => {
-                wsModelUtil.autoRestart = false
-                wsModelUtil.restart = vi.fn()
-
-                wsModelUtil.onClose();
-
-                expect(wsModelUtil.actions[wsModelUtil.ON_CLOSE_ACTION]).toBeCalled()
-                expect(wsModelUtil.restart).toBeCalledTimes(0)
-            })
-        })
-
-        describe('on error', () => {
-            beforeEach(() => {
-                wsModelUtil.restart = vi.fn()
-                wsModelUtil.close = vi.fn()
-            })
-            it('with autorestart', () => {
-                wsModelUtil.autoRestart = true
-
-                wsModelUtil.onError();
-
-                expect(wsModelUtil.actions[wsModelUtil.ON_ERROR_ACTION]).toBeCalled()
-                expect(wsModelUtil.restart).toBeCalled()
-                expect(wsModelUtil.close).toBeCalledTimes(0)
-            })
-
-            it('without autorestart', () => {
-                wsModelUtil.autoRestart = false
-                wsModelUtil.restart = vi.fn()
-
-                wsModelUtil.onError();
-
-                expect(wsModelUtil.actions[wsModelUtil.ON_ERROR_ACTION]).toBeCalled()
-                expect(wsModelUtil.close).toBeCalled()
-                expect(wsModelUtil.restart).toBeCalledTimes(0)
-            })
-        })
-
-        describe('on message', () => {
-            it('with type', () => {
-                const type = 'type'
-                const message = JSON.stringify({type})
-                wsModelUtil.actions[type] = vi.fn()
-
-                wsModelUtil.onMessage(message)
-
-                expect(wsModelUtil.actions[type]).toBeCalledWith({type})
-            })
-
-            describe('without type', () => {
-                it('success or no status', () => {
-                    wsModelUtil.onRefresh = true;
-                    wsModelUtil.actions[wsModelUtil.RESPONSE_HANDLER] = vi.fn()
-                    const message = JSON.stringify({msg: 'msg'})
-                
-                    
-                    wsModelUtil.onMessage(message)
-
-                    expect(wsModelUtil.onRefresh).toBe(false)
-                    expect(wsModelUtil.actions[wsModelUtil.RESPONSE_HANDLER]).toBeCalledWith({msg: 'msg'})
-                })
-
-                it('403 status (not in refresh)', () => {
-                    wsModelUtil.onRefresh = false;
-                    wsModelUtil.refreshAndExecuteLast = vi.fn()
-                    const message = JSON.stringify({status: 403})
-
-                    wsModelUtil.onMessage(message)
-
-                    expect(wsModelUtil.refreshAndExecuteLast).toBeCalled()
-                    expect(wsModelUtil.onRefresh).toBe(true)
-                })
-            })
-        })
-    })
-})
+          expect(wsModelUtil.refreshAndExecuteLast).toBeCalled();
+          expect(wsModelUtil.onRefresh).toBe(true);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Описание изменений
Добавлена моделька для общения с websocket API, встроены хэндлеры для колбэков сокета (новое сообщение, падение, закрытие). Добавлена возможность регистрировать колбэки на конкретные типы сообщений с апи, а также на респонсы.

### Тип изменений
- [x] Новая функциональность
- [ ] Исправление ошибок
- [ ] Улучшение существующего кода
- [ ] Другие изменения

### Тестирование
полное покрытие Unit тестами